### PR TITLE
Fix release workflow missing git dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
     container:
       image: node:lts-alpine3.23
     steps:
+      - name: Install git
+        run: apk add --no-cache git
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:


### PR DESCRIPTION
The release workflow uses a Node Alpine image which does not include git by default. semantic-release requires git to function properly. This change adds a step to install git using apk before checkout.

---
*PR created automatically by Jules for task [5837677151509917983](https://jules.google.com/task/5837677151509917983) started by @bl4ko*