### PR TITLE
fix(osv): fail closed on scanner errors and unknown severity

### DIFF
--- a/.github/workflows/osv.yml
+++ b/.github/workflows/osv.yml
@@ -50,8 +50,17 @@ jobs:
           ARGS=$(echo "$SCAN_ARGS" | tr '\n' ' ')
 
           # JSON output drives the severity/fixability gate below.
+          # Exit 0 = clean, 1 = vulns found; anything else means osv-scanner
+          # could not scan -> fail closed (do NOT let a broken scan pass).
           echo "Running osv-scanner (JSON)..."
-          osv-scanner $ARGS --format json --output osv-results.json || true
+          set +e
+          osv-scanner $ARGS --format json --output osv-results.json
+          code=$?
+          set -e
+          case "$code" in
+            0|1) ;;
+            *) echo "::error::osv-scanner could not scan (exit $code)"; exit "$code" ;;
+          esac
 
           if [ "$UPLOAD_SARIF" = "true" ]; then
             echo "Running osv-scanner (SARIF)..."
@@ -100,7 +109,7 @@ jobs:
           try:
               data = json.load(open(path, encoding="utf-8"))
           except (OSError, ValueError) as e:
-              print(f"No parseable scan results ({e}); treating as clean."); sys.exit(0)
+              print(f"::error::no parseable scan results ({e}); failing closed"); sys.exit(2)
 
           blocking, warnings = [], []
           for res in data.get("results", []):
@@ -113,9 +122,11 @@ jobs:
                       vid = v.get("id", "?")
                       sev = bucket_score(score.get(vid)) or bucket_label(v.get("database_specific", {}).get("severity"))
                       fx = fixable(v)
+                      # Fail closed: a fixable vuln with no parseable severity blocks.
+                      rank = ORDER[thr] if (fx and sev is None) else ORDER.get(sev or '', -1)
                       loc = f" [{src}]" if src else ""
                       line = f"  {sev or 'unknown':<8} {'fixable' if fx else 'no-fix':<7} {name}@{ver} {vid}{loc}"
-                      (blocking if fx and ORDER.get(sev or '', -1) >= ORDER[thr] else warnings).append(line)
+                      (blocking if fx and rank >= ORDER[thr] else warnings).append(line)
 
           if warnings:
               print(f"::group::OSV warnings (not blocking) - {len(warnings)}")

--- a/.github/workflows/osv_image.yml
+++ b/.github/workflows/osv_image.yml
@@ -65,10 +65,19 @@ jobs:
           FAIL_THRESHOLD: ${{ inputs.fail-on-severity }}
         run: |
           echo "Scanning image: $IMAGE"
-          # Human-readable log + machine-readable JSON for the gate.
+          # Human-readable log (non-gating) + machine-readable JSON for the gate.
           "$RUNNER_TEMP/osv-scanner" scan image "$IMAGE" || true
+          # Exit 0 = clean, 1 = vulns found; anything else means osv-scanner
+          # could not scan -> fail closed.
+          set +e
           "$RUNNER_TEMP/osv-scanner" scan image "$IMAGE" \
-            --format json --output osv-results.json || true
+            --format json --output osv-results.json
+          code=$?
+          set -e
+          case "$code" in
+            0|1) ;;
+            *) echo "::error::osv-scanner could not scan image (exit $code)"; exit "$code" ;;
+          esac
 
           cat > "$RUNNER_TEMP/osv_gate.py" <<'PYEOF'
           import json, sys
@@ -101,7 +110,7 @@ jobs:
           try:
               data = json.load(open(path, encoding="utf-8"))
           except (OSError, ValueError) as e:
-              print(f"No parseable scan results ({e}); treating as clean."); sys.exit(0)
+              print(f"::error::no parseable scan results ({e}); failing closed"); sys.exit(2)
 
           blocking, warnings = [], []
           for res in data.get("results", []):
@@ -114,9 +123,11 @@ jobs:
                       vid = v.get("id", "?")
                       sev = bucket_score(score.get(vid)) or bucket_label(v.get("database_specific", {}).get("severity"))
                       fx = fixable(v)
+                      # Fail closed: a fixable vuln with no parseable severity blocks.
+                      rank = ORDER[thr] if (fx and sev is None) else ORDER.get(sev or '', -1)
                       loc = f" [{src}]" if src else ""
                       line = f"  {sev or 'unknown':<8} {'fixable' if fx else 'no-fix':<7} {name}@{ver} {vid}{loc}"
-                      (blocking if fx and ORDER.get(sev or '', -1) >= ORDER[thr] else warnings).append(line)
+                      (blocking if fx and rank >= ORDER[thr] else warnings).append(line)
 
           if warnings:
               print(f"::group::OSV warnings (not blocking) - {len(warnings)}")


### PR DESCRIPTION
Hardens the fixability gate (merged in #154) against fail-open states flagged by automated security review.

## Findings addressed
- **[HIGH] Fail-open on scanner error** — `osv-scanner ... || true` + `sys.exit(0)` on missing results meant a *crashed/misconfigured scanner produced green CI*. Now: a non-`0`/`1` osv-scanner exit (e.g. `127`/`128` = could-not-scan) fails the step; missing/corrupt JSON exits `2` (fail closed).
- **[MEDIUM] Fail-open on unknown severity** — a *fixable* vuln with no parseable severity dropped silently into warnings. Now it is **blocked** (fail closed).

`|| true` is kept only on the non-gating human-readable / SARIF-upload invocations.

## Verified
Gate re-tested against synthetic + real osv-scanner v2.3.8 JSON:
- unknown-severity fixable → blocks (was: passed)
- missing results file → exit 2 (was: exit 0)
- existing behaviour preserved: fixable-high blocks, no-fix + below-threshold warn, clean scan passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)