### PR TITLE
fix(renovate): opt own ghcr images out of minimumReleaseAge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,6 +37,16 @@
       "automerge": true
     },
     {
+      "description": "Own freshly-built ghcr images rebuild several times a day; the global 3-day minimumReleaseAge clock resets on every digest rebase, deadlocking automerge. Opt them out so digest bumps automerge immediately.",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "ghcr.io/bl4ko/**"
+      ],
+      "minimumReleaseAge": null
+    },
+    {
       "matchManagers": [
         "github-actions"
       ],


### PR DESCRIPTION
## Problem

Renovate digest PRs for our own `ghcr.io/bl4ko/ci-tools:latest` image never automerge and pile up (e.g. #152 sat open 5 days, flagged `[manual]` by github-checker).

**Root cause:** global `minimumReleaseAge: "3 days"` gates a `renovate/stability-days` status check. `ci-tools:latest` rebuilds **several times a day** (4× on 2026-06-13 alone). Every rebuild → new digest → Renovate rebases the open PR onto it → the 3-day clock **resets**. Rebuilds outpace the window, so the check never passes, automerge never fires, and Renovate eventually trips its anti-flap guard ("matching PR was automerged previously") and hands it to a human.

`minimumReleaseAge` is meant for third-party deps — applying it to our own freshly-built image is what creates the deadlock.

## Fix

Add a packageRule setting `minimumReleaseAge: null` for `ghcr.io/bl4ko/**` (docker datasource) so own-image digest bumps pass stability instantly and automerge.

`null` is the [documented opt-out](https://docs.renovatebot.com/key-concepts/minimum-release-age/) for per-package minimum-release-age. Third-party deps keep the 3-day safety window.

## Notes

- #152 was already admin-merged to clear the active alert; this prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)