### PR TITLE
feat(ci): docker+buildx in ci-tools + job-container input on build_image

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -49,6 +49,11 @@ on:
         required: false
         type: string
         default: ""
+      job-container:
+        description: "Container image to run the job in (required on ARC kubernetes-mode runners; needs docker+buildx). Empty = run on the host runner."
+        required: false
+        type: string
+        default: ""
     secrets:
       HARBOR_ROBOT_USER:
         required: false
@@ -70,6 +75,7 @@ permissions:
 jobs:
   build-and-scan:
     runs-on: ${{ inputs.runs-on }}
+    container: ${{ inputs.job-container || null }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/ci-image/Dockerfile
+++ b/ci-image/Dockerfile
@@ -20,6 +20,10 @@ ARG GH_CLI_VERSION=2.95.0
 ARG YQ_VERSION=v4.53.3
 # renovate: datasource=github-releases depName=gitleaks/gitleaks
 ARG GITLEAKS_VERSION=v8.30.1
+# renovate: datasource=docker depName=docker
+ARG DOCKER_VERSION=29.6.0
+# renovate: datasource=github-releases depName=docker/buildx
+ARG BUILDX_VERSION=v0.35.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates curl git jq make python3 && \
@@ -69,6 +73,16 @@ RUN GITLEAKS_ARCH=$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETAR
     GITLEAKS_STRIPPED=$(echo "$GITLEAKS_VERSION" | sed 's/^v//') && \
     curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_STRIPPED}_linux_${GITLEAKS_ARCH}.tar.gz" \
       | tar -xz -C /usr/local/bin gitleaks && chmod +x /usr/local/bin/gitleaks
+
+# docker CLI (client only) + buildx plugin — remote-buildkit image builds in CI
+RUN DOCKER_ARCH=$([ "$TARGETARCH" = "amd64" ] && echo "x86_64" || echo "aarch64") && \
+    curl -fsSL "https://download.docker.com/linux/static/stable/${DOCKER_ARCH}/docker-${DOCKER_VERSION}.tgz" \
+      | tar -xz -C /usr/local/bin --strip-components=1 docker/docker && \
+    chmod +x /usr/local/bin/docker && \
+    mkdir -p /usr/local/lib/docker/cli-plugins && \
+    curl -fsSL -o /usr/local/lib/docker/cli-plugins/docker-buildx \
+      "https://github.com/docker/buildx/releases/download/${BUILDX_VERSION}/buildx-${BUILDX_VERSION}.linux-${TARGETARCH}" && \
+    chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx
 
 # Non-root user for hardened ARC workflow pods
 RUN groupadd -g 1001 runner && \


### PR DESCRIPTION
Enables slocar's in-cluster Harbor publish path (option B).

**ci-image/Dockerfile** — add docker CLI (static client, 29.6.0) + buildx plugin (v0.35.0). ci-tools is ubuntu glibc + uid 1001, so it runs as the ARC job container and can drive `docker buildx --driver remote` against the in-cluster buildkitd.

**build_image.yml** — new `job-container` input → sets `container:` on the build job. Required on ARC kubernetes-mode runners (which forbid container-less jobs); empty default keeps host-runner behaviour.

Follow-ups (separate PRs): gitops hook-template mounts the buildkit mTLS certs into job pods; slocar release.yml passes `job-container` + bumps the build_image pin.