### PR TITLE
feat(ci): cosign in ci-tools, drop cosign-installer (fixes slocar sign 127)

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -160,10 +160,6 @@ jobs:
           cache-from: ${{ inputs.push && format('type=registry,ref={0}', steps.cache.outputs.repo) || '' }}
           cache-to: ${{ inputs.push && format('type=registry,ref={0},mode=max', steps.cache.outputs.repo) || '' }}
 
-      - name: Install cosign
-        if: inputs.push && inputs.sign && inputs.harbor-tags != ''
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
       - name: Sign Harbor images (key-based, by digest)
         if: inputs.push && inputs.sign && inputs.harbor-tags != ''
         env:
@@ -171,8 +167,7 @@ jobs:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           DIGEST: ${{ steps.build.outputs.digest }}
         run: |
-          # Sign each pushed Harbor image by its immutable manifest digest (one sig covers all
-          # tags of that image). Strip the :tag, dedupe, so a name isn't signed twice.
+          # sign by digest (one sig per image); strip :tag + dedupe so a name isn't signed twice
           echo "${{ inputs.harbor-tags }}" | tr ',' '\n' | sed 's/:[^/]*$//' | sort -u | while read -r name; do
             [ -z "$name" ] && continue
             cosign sign --key env://COSIGN_PRIVATE_KEY --yes "${name}@${DIGEST}"

--- a/ci-image/Dockerfile
+++ b/ci-image/Dockerfile
@@ -24,6 +24,8 @@ ARG GITLEAKS_VERSION=v8.30.1
 ARG DOCKER_VERSION=29.6.0
 # renovate: datasource=github-releases depName=docker/buildx
 ARG BUILDX_VERSION=v0.35.0
+# renovate: datasource=github-releases depName=sigstore/cosign
+ARG COSIGN_VERSION=v3.1.1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates curl git jq make python3 && \
@@ -83,6 +85,11 @@ RUN DOCKER_ARCH=$([ "$TARGETARCH" = "amd64" ] && echo "x86_64" || echo "aarch64"
     curl -fsSL -o /usr/local/lib/docker/cli-plugins/docker-buildx \
       "https://github.com/docker/buildx/releases/download/${BUILDX_VERSION}/buildx-${BUILDX_VERSION}.linux-${TARGETARCH}" && \
     chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx
+
+# cosign (image signing in CI)
+RUN curl -fsSL -o /usr/local/bin/cosign \
+      "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-${TARGETARCH}" && \
+    chmod +x /usr/local/bin/cosign
 
 # Non-root user for hardened ARC workflow pods
 RUN groupadd -g 1001 runner && \


### PR DESCRIPTION
slocar release built+pushed to Harbor fine but failed at **Install cosign** (exit 127): `sigstore/cosign-installer` runs `$SUDO` (=`sudo` when non-root), and the ci-tools job container runs as uid 1001 with no `sudo` installed → `sudo: not found`.

Bake the cosign binary into ci-tools (v3.1.1, same pattern as crane/gh/yq/gitleaks) and drop the `cosign-installer` step from `build_image.yml` — the sign step calls the pre-installed `cosign` directly. After ci-tools rebuilds, slocar's release.yml job-container pin gets bumped.