### PR TITLE
fix(ci): validate/scan images by digest, not tag

### DIFF
--- a/.github/workflows/scan_images.yml
+++ b/.github/workflows/scan_images.yml
@@ -71,7 +71,7 @@ jobs:
 
           # Extract images from HEAD version of changed files
           HEAD_IMAGES=$(echo "$CHANGED_FILES" | xargs grep -hE '^\s*(image|value):\s*\S+' 2>/dev/null \
-            | grep -oE '[a-zA-Z0-9._/-]+:[a-zA-Z0-9._-]+' \
+            | grep -oE '[a-zA-Z0-9._/-]+:[a-zA-Z0-9._-]+(@sha256:[a-f0-9]{64})?' \
             | grep -E '^[a-z]' \
             | grep -vE '^\s*#' \
             | grep '/' \

--- a/.github/workflows/validate_images.yml
+++ b/.github/workflows/validate_images.yml
@@ -52,7 +52,7 @@ jobs:
 
           # Extract unique image references from changed files
           IMAGES=$(echo "$CHANGED_FILES" | xargs grep -hE '^\s*(image|value):\s*\S+' 2>/dev/null \
-            | grep -oE '[a-zA-Z0-9._/-]+:[a-zA-Z0-9._-]+' \
+            | grep -oE '[a-zA-Z0-9._/-]+:[a-zA-Z0-9._-]+(@sha256:[a-f0-9]{64})?' \
             | grep -E '^[a-z]' \
             | grep -vE '^\s*#' \
             | grep '/' \
@@ -70,7 +70,7 @@ jobs:
           FAILED=0
           for img in $IMAGES; do
             echo -n "Checking $img ... "
-            if timeout 30 crane manifest "$img" > /dev/null 2>&1; then
+            if timeout 60 crane manifest "$img" > /dev/null 2>&1; then
               echo "OK"
             else
               echo "FAILED"


### PR DESCRIPTION
## Why CI false-redded on Harbor images (and why retry was the wrong fix)
The manifests pin images by `@sha256:…`, but the extraction regex stopped at the tag (`repo:tag`) and threw the digest away. So `validate`/`scan` ran `crane manifest`/`crane pull` on the **tag** → Harbor had to do a **tag→manifest resolution** (a DB lookup that's the slow, lock-contended path). Under load that spiked past the 30s timeout and the check went red — even though the image was fine (containerd pulled the same digest in 13s, `harbor.xqx.uk/v2/` answered in 0.02s from the runner namespace).

## Fix — efficiency, not a band-aid
Capture the `@sha256:…` digest and let crane do a **direct content-addressed lookup**. No tag resolution, so it's fast *and* it verifies exactly what gets deployed. Dropped the retry I'd first added — with the digest path there's nothing to ride out.

- `validate`: `crane manifest repo:tag@sha256:…` (digest)
- `scan`: pulls the new/changed images by digest

## Note for consumers
shared-actions is SHA-pinned in callers — bump the pin to pick this up (Renovate, or manual for urgent).