### PR TITLE
feat(ci): authenticate private Harbor pulls

### DIFF
--- a/.github/workflows/scan_images.yml
+++ b/.github/workflows/scan_images.yml
@@ -19,6 +19,10 @@ on:
       GHCR_TOKEN:
         required: false
         description: "PAT with read:packages for private GHCR images"
+      HARBOR_USERNAME:
+        required: false
+      HARBOR_PASSWORD:
+        required: false
 
 permissions:
   contents: read
@@ -39,6 +43,13 @@ jobs:
         env:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN || github.token }}
         run: crane auth login ghcr.io -u "$GITHUB_ACTOR" -p "$GHCR_TOKEN"
+
+      - name: Login to Harbor
+        env:
+          HARBOR_USERNAME: ${{ secrets.HARBOR_USERNAME }}
+          HARBOR_PASSWORD: ${{ secrets.HARBOR_PASSWORD }}
+        if: env.HARBOR_USERNAME != '' && env.HARBOR_PASSWORD != ''
+        run: crane auth login harbor.xqx.uk -u "$HARBOR_USERNAME" -p "$HARBOR_PASSWORD"
 
       - name: Login to Docker Hub
         env:

--- a/.github/workflows/validate_images.yml
+++ b/.github/workflows/validate_images.yml
@@ -10,6 +10,10 @@ on:
       GHCR_TOKEN:
         required: false
         description: "PAT with read:packages for private GHCR images"
+      HARBOR_USERNAME:
+        required: false
+      HARBOR_PASSWORD:
+        required: false
 
 permissions:
   contents: read
@@ -30,6 +34,13 @@ jobs:
         env:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN || github.token }}
         run: crane auth login ghcr.io -u "$GITHUB_ACTOR" -p "$GHCR_TOKEN"
+
+      - name: Login to Harbor
+        env:
+          HARBOR_USERNAME: ${{ secrets.HARBOR_USERNAME }}
+          HARBOR_PASSWORD: ${{ secrets.HARBOR_PASSWORD }}
+        if: env.HARBOR_USERNAME != '' && env.HARBOR_PASSWORD != ''
+        run: crane auth login harbor.xqx.uk -u "$HARBOR_USERNAME" -p "$HARBOR_PASSWORD"
 
       - name: Extract and validate image references
         env:


### PR DESCRIPTION
Adds optional Harbor credentials to the reusable image validation and vulnerability scan workflows so private hardened images remain testable.